### PR TITLE
auth2: Add revoke token, update logout

### DIFF
--- a/dist/Auth2.js
+++ b/dist/Auth2.js
@@ -117,7 +117,7 @@ define(["require", "exports", "./Cookie", "./Html", "./HttpClient"], function (r
         Auth2.prototype.removeLink = function (token, config) {
             var httpClient = new HttpClient_1.HttpClient();
             return httpClient.request({
-                method: 'DELETE',
+                method: 'POST',
                 withCredentials: true,
                 header: {
                     Authorization: token,

--- a/dist/Auth2Session.js
+++ b/dist/Auth2Session.js
@@ -118,15 +118,27 @@ define(["require", "exports", "./Cookie", "./Auth2", "./Utils", "bluebird"], fun
                 return result;
             });
         };
-        Auth2Session.prototype.logout = function () {
+        Auth2Session.prototype.logout = function (tokenId) {
+            var _this = this;
+            return this.getTokenInfo()
+                .then(function (tokenInfo) {
+                var currentTokenId = _this.session ? _this.session.tokenInfo.id : null;
+                if (tokenId && tokenId !== currentTokenId) {
+                    throw new Error('Supplied token id does not match the current token id, will not log out');
+                }
+                return _this.auth2Client.revokeToken(_this.getToken(), tokenInfo.id);
+            })
+                .then(function () {
+                _this.removeSessionCookie();
+                return _this.evaluateSession();
+            });
+        };
+        Auth2Session.prototype.revokeToken = function (tokenId) {
+            var _this = this;
             var that = this;
             return this.getTokenInfo()
                 .then(function (tokenInfo) {
-                return that.auth2Client.revokeToken(that.getToken(), tokenInfo.id);
-            })
-                .then(function () {
-                that.removeSessionCookie();
-                return that.evaluateSession();
+                return _this.auth2Client.revokeToken(_this.getToken(), tokenId);
             });
         };
         Auth2Session.prototype.onChange = function (listener) {

--- a/src/Auth2.ts
+++ b/src/Auth2.ts
@@ -329,7 +329,7 @@ export class Auth2 {
         let httpClient = new HttpClient();
 
         return httpClient.request({
-            method: 'DELETE',
+            method: 'POST',
             withCredentials: true,
             header: {
                 Authorization: token,

--- a/src/Auth2Session.ts
+++ b/src/Auth2Session.ts
@@ -179,15 +179,26 @@ export class Auth2Session {
             });
     }         
 
-    logout() : Promise<any> {
-        let that = this;
+    logout(tokenId?: string) : Promise<any> {
         return this.getTokenInfo()
-            .then(function (tokenInfo) {
-                return that.auth2Client.revokeToken(that.getToken(), tokenInfo.id);
+            .then((tokenInfo) => {
+                var currentTokenId = this.session ? this.session.tokenInfo.id : null;
+                if (tokenId && tokenId !== currentTokenId) {
+                    throw new Error('Supplied token id does not match the current token id, will not log out');
+                }
+                return this.auth2Client.revokeToken(this.getToken(), tokenInfo.id);
             })
             .then(() => {
-                that.removeSessionCookie();
-                return that.evaluateSession();
+                this.removeSessionCookie();
+                return this.evaluateSession();
+            });
+    }
+
+    revokeToken(tokenId: string) : Promise<any> {
+        let that = this;
+        return this.getTokenInfo()
+            .then((tokenInfo) => {
+                return this.auth2Client.revokeToken(this.getToken(), tokenId);
             });
     }
 


### PR DESCRIPTION
- logout now takes a token id; if it doesn't match the current session's token id, fails; supports ui usage in which a the current session is displayed with an associated logout (should not log out if the browser session has magically changed.)