### PR TITLE
Separate loginCreate into pure create and sesssion initialization.

### DIFF
--- a/dist/Auth2Session.js
+++ b/dist/Auth2Session.js
@@ -102,15 +102,11 @@ define(["require", "exports", "./Cookie", "./Auth2", "./Auth2Error", "./Utils", 
             });
         };
         Auth2Session.prototype.loginCreate = function (data) {
-            var _this = this;
-            return this.auth2Client.loginCreate(data)
-                .then(function (result) {
-                _this.setSessionCookie(result.token.token, result.token.expires);
-                return _this.evaluateSession()
-                    .then(function () {
-                    return result;
-                });
-            });
+            return this.auth2Client.loginCreate(data);
+        };
+        Auth2Session.prototype.initializeSession = function (tokenInfo) {
+            this.setSessionCookie(tokenInfo.token, tokenInfo.expires);
+            return this.evaluateSession();
         };
         Auth2Session.prototype.loginUsernameSuggest = function (username) {
             return this.auth2Client.loginUsernameSuggest(username);

--- a/src/Auth2Session.ts
+++ b/src/Auth2Session.ts
@@ -169,14 +169,12 @@ export class Auth2Session {
     }
 
     loginCreate(data: ILoginCreateOptions): Promise<any> {
-        return this.auth2Client.loginCreate(data)
-            .then((result) => {
-                this.setSessionCookie(result.token.token, result.token.expires);
-                return this.evaluateSession()
-                    .then(() => {
-                        return result;
-                    });
-            });
+        return this.auth2Client.loginCreate(data);
+    }
+
+    initializeSession(tokenInfo: any): Promise<any> {
+        this.setSessionCookie(tokenInfo.token, tokenInfo.expires);
+        return this.evaluateSession();
     }
 
     loginUsernameSuggest(username: string): Promise<any> {


### PR DESCRIPTION
- they had been combined into one method to bundle the actions for ease of consumption, but now we need to insert profile creation in between creation and setting the session.