### PR TITLE
Utilize auth2 logout api call rather than revokeToken for the auth2 s…

### DIFF
--- a/dist/Auth2.js
+++ b/dist/Auth2.js
@@ -167,6 +167,21 @@ define(["require", "exports", "./Html", "./HttpUtils", "./HttpClient", "./Auth2C
                 return _this.processResult(result, 204);
             });
         };
+        Auth2.prototype.logout = function (token) {
+            var _this = this;
+            var httpClient = new Auth2Client_1.AuthClient();
+            return httpClient.request({
+                method: 'POST',
+                withCredentials: true,
+                header: new HttpClient_1.HttpHeader({
+                    'content-type': 'application/json'
+                }),
+                url: this.makePath(endpoints.logout)
+            })
+                .then(function (result) {
+                return _this.processResult(result, 200);
+            });
+        };
         Auth2.prototype.revokeToken = function (token, tokenid) {
             var _this = this;
             var httpClient = new Auth2Client_1.AuthClient();
@@ -177,7 +192,7 @@ define(["require", "exports", "./Html", "./HttpUtils", "./HttpClient", "./Auth2C
                     authorization: token,
                     'content-type': 'application/json'
                 }),
-                url: this.config.baseUrl + '/' + endpoints.tokensRevoke + '/' + tokenid
+                url: this.makePath([endpoints.tokensRevoke, tokenid])
             })
                 .then(function (result) {
                 return _this.processResult(result, 204);
@@ -193,7 +208,7 @@ define(["require", "exports", "./Html", "./HttpUtils", "./HttpClient", "./Auth2C
                     authorization: token,
                     'content-type': 'application/json'
                 }),
-                url: this.config.baseUrl + '/' + endpoints.tokensRevokeAll
+                url: this.makePath(endpoints.tokensRevokeAll)
             })
                 .then(function (result) {
                 return _this.processResult(result, 204);
@@ -220,7 +235,7 @@ define(["require", "exports", "./Html", "./HttpUtils", "./HttpClient", "./Auth2C
             return httpClient.request({
                 method: 'GET',
                 withCredentials: true,
-                url: this.config.baseUrl + '/' + endpoints.apiMe,
+                url: this.makePath(endpoints.apiMe),
                 header: new HttpClient_1.HttpHeader({
                     authorization: token,
                     accept: 'application/json'

--- a/dist/Auth2Session.js
+++ b/dist/Auth2Session.js
@@ -153,15 +153,7 @@ define(["require", "exports", "./Cookie", "./Auth2", "./Auth2Error", "./Utils", 
         };
         Auth2Session.prototype.logout = function (tokenId) {
             var _this = this;
-            return this.getTokenInfo()
-                .then(function (tokenInfo) {
-                var session = _this.getSession();
-                var currentTokenId = session ? session.tokenInfo.id : null;
-                if (tokenId && tokenId !== currentTokenId) {
-                    throw new Error('Supplied token id does not match the current token id, will not log out');
-                }
-                return _this.auth2Client.revokeToken(_this.getToken(), tokenInfo.id);
-            })
+            return this.auth2Client.logout(this.getToken())
                 .then(function () {
                 _this.removeSessionCookie();
                 return _this.evaluateSession();

--- a/src/Auth2.ts
+++ b/src/Auth2.ts
@@ -421,6 +421,21 @@ export class Auth2 {
             });
     }
 
+    logout(token: string): Promise<any> {
+        let httpClient = new AuthClient();
+
+        return httpClient.request({
+            method: 'POST',
+            withCredentials: true,
+            header: new HttpHeader({
+                'content-type': 'application/json'
+            }),
+            url: this.makePath(endpoints.logout)
+        })
+        .then((result: Response) => {
+            return this.processResult(result, 200);
+        })
+    }
 
     revokeToken(token: string, tokenid: string): Promise<any> {
         let httpClient = new AuthClient();
@@ -432,7 +447,7 @@ export class Auth2 {
                 authorization: token,
                 'content-type': 'application/json'
             }),
-            url: this.config.baseUrl + '/' + endpoints.tokensRevoke + '/' + tokenid
+            url: this.makePath([endpoints.tokensRevoke, tokenid])
         })
             .then((result: Response) => {
                 return this.processResult(result, 204);
@@ -449,7 +464,7 @@ export class Auth2 {
                 authorization: token,
                 'content-type': 'application/json'
             }),
-            url: this.config.baseUrl + '/' + endpoints.tokensRevokeAll
+            url: this.makePath(endpoints.tokensRevokeAll)
         })
             .then((result: Response) => {
                 return this.processResult(result, 204);
@@ -476,7 +491,7 @@ export class Auth2 {
         return httpClient.request({
             method: 'GET',
             withCredentials: true,
-            url: this.config.baseUrl + '/' + endpoints.apiMe,
+            url: this.makePath(endpoints.apiMe),
             header: new HttpHeader({
                 authorization: token,
                 accept: 'application/json'

--- a/src/Auth2Session.ts
+++ b/src/Auth2Session.ts
@@ -251,15 +251,7 @@ export class Auth2Session {
     }
 
     logout(tokenId?: string): Promise<any> {
-        return this.getTokenInfo()
-            .then((tokenInfo) => {
-                var session = this.getSession();
-                var currentTokenId = session ? session.tokenInfo.id : null;
-                if (tokenId && tokenId !== currentTokenId) {
-                    throw new Error('Supplied token id does not match the current token id, will not log out');
-                }
-                return this.auth2Client.revokeToken(this.getToken(), tokenInfo.id);
-            })
+        return this.auth2Client.logout(this.getToken())
             .then(() => {
                 this.removeSessionCookie();
                 return this.evaluateSession();


### PR DESCRIPTION
…ession logout call

- logout also removes any temporary link or login tokens used, and simpler calling interface
- revokeToken still used for the token management tool